### PR TITLE
Don't pass SSL cert as verify parameter.

### DIFF
--- a/adp_connection/lib/adpapiconnection.py
+++ b/adp_connection/lib/adpapiconnection.py
@@ -189,8 +189,7 @@ class AuthorizationCodeConnection(ADPAPIConnection):
                           headers=(headers),
                           cert=(self.getConfig().getSSLCertPath(),
                                 self.getConfig().getSSLKeyPath()),
-                          data=(formData),
-                          verify=(self.getConfig().getSSLCertPath()))
+                          data=(formData))
         logging.debug(r.status_code)
         logging.debug(r.json())
         if (r.status_code == requests.codes.ok):


### PR DESCRIPTION
https://2.python-requests.org/en/master/user/advanced/#ssl-cert-verification
The `verify` parameter is used to specify CAs.