### PR TITLE
Removed log statment that would pring access tokens

### DIFF
--- a/adp_connection/lib/adpapiconnection.py
+++ b/adp_connection/lib/adpapiconnection.py
@@ -96,7 +96,6 @@ class ADPAPIConnection(object):
                                     self.getConfig().getClientSecret()),
                               data=(formData))
             logging.debug(r.status_code)
-            logging.debug(r.json())
             if (r.status_code == requests.codes.ok):
                 self.connection['status'] = 'connected'
                 self.connection['token'] = r.json()['access_token']


### PR DESCRIPTION
in adpapiconnection.py there is a print statement (line 99) that logs the result of getting an access token. This should not be logged as it contains sensitive data.